### PR TITLE
Fix TypeScript transpiling errors during deployment

### DIFF
--- a/deploy.cmd
+++ b/deploy.cmd
@@ -101,7 +101,7 @@ call :SelectNodeVersion
 :: 3. Install npm packages
 IF EXIST "%DEPLOYMENT_TARGET%\package.json" (
   pushd "%DEPLOYMENT_TARGET%"
-  call :ExecuteCmd !NPM_CMD! install --production
+  call :ExecuteCmd !NPM_CMD! install
   IF !ERRORLEVEL! NEQ 0 goto error
   popd
 )


### PR DESCRIPTION
TypeScript transpiling invoked during deploymet (`deploy.cmd`) fails due to missing dependencies defined in `devDependencies` section of `package.json`. Removing `--production` causes `npm install` to pull all the dependencies, fixing transpiling errors.

Resolves #15